### PR TITLE
fix windows path error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,12 @@ impl zed::Extension for DockerfileExtension {
                 env::current_dir()
                     .unwrap()
                     .join(&server_path)
-                    .to_string_lossy()
-                    .to_string(),
+                    .canonicalize()
+                    .unwrap_or_else(|_| env::current_dir().unwrap().join(&server_path))
+                    .to_str()
+                    .unwrap()
+                    .replace("/C:", "C:")
+                    .replace("\\", "/"),
                 "--stdio".to_string(),
             ],
             env: Default::default(),


### PR DESCRIPTION
Similar: https://github.com/zed-extensions/vue/pull/5

```
Language server error: dockerfile-language-server

oneshot canceled
-- stderr--
node:internal/modules/cjs/loader:1252
  throw err;
  ^

Error: Cannot find module 'D:\C:\Users\trong\AppData\Local\Zed\extensions\work\dockerfile\node_modules\dockerfile-language-server-nodejs\bin\docker-langserver'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1249:15)
    at Function._load (node:internal/modules/cjs/loader:1075:27)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.11.0
```